### PR TITLE
Support custom host

### DIFF
--- a/commands/data_api.js
+++ b/commands/data_api.js
@@ -3,6 +3,7 @@
 let cli = require('heroku-cli-util')
 let co = require('co')
 let fs = require('co-fs')
+let util = require('../lib/util.js')
 
 module.exports = {
   topic: 'data-api',
@@ -37,7 +38,7 @@ Example:
     let request = {
       method: context.args.method.toUpperCase(),
       path: context.args.path,
-      host: 'postgres-api.heroku.com' // TODO: support yobuko
+      host: util.host()
     }
     if (['PATCH', 'PUT', 'POST'].includes(request.method)) {
       request.body = yield fs.readFile('/dev/stdin', 'utf8')

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,15 @@
+'use strict'
+
+let DEFAULT_HOST = 'postgres-api.heroku.com'
+
+function host () {
+  if (process.env.HEROKU_DATA_HOST) {
+    return process.env.HEROKU_DATA_HOST
+  } else {
+    return DEFAULT_HOST
+  }
+}
+
+module.exports = {
+  host: host
+}


### PR DESCRIPTION
I'd like the ability to support a custom host for the postgres API URL. 

I'm hoping it can be used like:
`HEROKU_DATA_HOST=postgres-api-camille.herokai.com heroku data-api GET /client/v11/databases/postgresql-awesome-12345`